### PR TITLE
Add Base Docker for Development Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,11 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# IDE-Specific Ignores
 .vscode/settings.json
+.idea/
+*.iml
+
+# Local development override files
+docker-compose.dev.yml
+Dockerfile-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.9
+
+# Set this both here and in pyproject.toml
+ENV POETRY_VERSION=1.0.0
+ENV APP_ROOT=/app
+
+# set to production to disable dev package installs
+ENV APP_ENV="development"
+
+RUN pip install "poetry==$POETRY_VERSION"
+RUN poetry config virtualenvs.create false
+
+# Handle dependency caching in a sane manner
+WORKDIR $APP_ROOT/
+COPY poetry.lock pyproject.toml $APP_ROOT/
+RUN poetry install --no-interaction --no-ansi $(test "$APP_ENV" = "production" && echo "--no-dev")
+
+# Copy in the rest of the project
+COPY . $APP_ROOT/
+
+# Run the bot (headless/override, better for actual app run and IDE-based development)
+CMD python -m bot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-slim
 
 # Set this both here and in pyproject.toml
 ENV POETRY_VERSION=1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"  # optional since v1.27.0
+services:
+  bot:
+    build: .
+    env_file: .env
+    environment:
+      REDIS_URL: "redis://redis:6379/1"
+    links:
+      - redis
+
+  redis:
+    image: redis
+    entrypoint: redis-server --appendonly yes
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     env_file: .env
     environment:
       REDIS_URL: "redis://redis:6379/1"
-    links:
+    depends_on:
       - redis
 
   redis:


### PR DESCRIPTION
This pull request adds a `Dockerfile` and `docker-compose.yml` configuration for the bot. It builds against Python 3.9 for both dev-like and prod-like environments.

Of note in this Docker configuration:

* Bind mounds are not provided by default through `docker-compose.yml`. This can be overridden by end developers if they so choose, but exists to provide easier compatibility and reproducibility in IDE-based development situations.
* Poetry's `venv` components are disabled entirely, instead installing things to system directly. As this is happening within a Docker context, this should be fine.
* Redis is ready at `redis://redis:6379` with persistence enabled and stored to a volume. By default, Redis is also exposed on host port 6379.
* An environment variable `APP_ENV` exists, which when set to `production` will disable the installation of dev-level dependencies as specified in `pyproject.toml`.