### PR TITLE
Implementation of /timestamp command

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -70,7 +70,7 @@ DMA_SERIES_IDS = {
     2: "360010792534",
     3: "360011920293",
     4: "360011920313",
-    5: "123456789012",  # Fake series ID as no 5 exist yet.
+    5: "4405269416471",
 }
 DMA_CATEGORY_NAMES = {
     0: "Foundational Understanding",

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -52,7 +52,9 @@ PRONOUN_OPTIONS = [
 ]
 
 DMA_API_URL = "https://discordmoderatoracademy.zendesk.com/api/v2/help_center/en-us/articles"
-DMA_API_SEARCH_URL = "https://discordmoderatoracademy.zendesk.com/api/v2/help_center/articles/search"
+DMA_API_SEARCH_URL = (
+    "https://discordmoderatoracademy.zendesk.com/api/v2/help_center/articles/search"
+)
 
 DMA_TITLE_REGEX = r"^\d\d\d:\s.*$"
 DMA_QUERY_REGEX = r"[{}]"
@@ -98,50 +100,17 @@ def get_days(year: int, month: int):
 
 
 TIMESTAMP_MAKE_BOUNDARIES = [
-    {
-        "name": "year",
-        "min": 1,
-        "max": 9998
-    },
-    {
-        "name": "month",
-        "min": 1,
-        "max": 12
-    },
-    {
-        "name": "day",
-        "min": 1,
-        "max": get_days
-    },
-    {
-        "name": "hour",
-        "min": 0,
-        "max": 23
-    },
-    {
-        "name": "minute",
-        "min": 0,
-        "max": 59
-    },
-    {
-        "name": "utc",
-        "min": -12,
-        "max": 14
-    },
+    {"name": "year", "min": 1, "max": 9998},
+    {"name": "month", "min": 1, "max": 12},
+    {"name": "day", "min": 1, "max": get_days},
+    {"name": "hour", "min": 0, "max": 23},
+    {"name": "minute", "min": 0, "max": 59},
+    {"name": "utc", "min": -12, "max": 14},
 ]
 TIMESTAMP_RELATIVE_BOUNDARIES = [
-    {
-        "name": "days",
-        "range": 730500  # +- 2000 years, keeping well between 1 and 9999 for year
-    },
-    {
-        "name": "hours",
-        "range": 23
-    },
-    {
-        "name": "minutes",
-        "range": 59
-    },
+    {"name": "days", "range": 730500},  # +- 2000 years, keeping well between 1 and 9999 for year
+    {"name": "hours", "range": 23},
+    {"name": "minutes", "range": 59},
 ]
 
 BOT_DEVS = [165023948638126080, 141288766760288256, 249287049482338305]

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -1,4 +1,5 @@
 from discord_slash.utils.manage_commands import create_choice
+from calendar import monthrange
 
 GUILDS_PRONOUN_ROLES = {
     # Discord Developer Discord
@@ -90,5 +91,57 @@ AUTOROLE_CONFIG = {
         "MEMBER": 687070754671558718,
     },
 }
+
+
+def get_days(year: int, month: int):
+    return monthrange(year, month)[1]
+
+
+TIMESTAMP_MAKE_BOUNDARIES = [
+    {
+        "name": "year",
+        "min": 1,
+        "max": 9998
+    },
+    {
+        "name": "month",
+        "min": 1,
+        "max": 12
+    },
+    {
+        "name": "day",
+        "min": 1,
+        "max": get_days
+    },
+    {
+        "name": "hour",
+        "min": 0,
+        "max": 23
+    },
+    {
+        "name": "minute",
+        "min": 0,
+        "max": 59
+    },
+    {
+        "name": "utc",
+        "min": -12,
+        "max": 14
+    },
+]
+TIMESTAMP_RELATIVE_BOUNDARIES = [
+    {
+        "name": "days",
+        "range": 730500  # +- 2000 years, keeping well between 1 and 9999 for year
+    },
+    {
+        "name": "hours",
+        "range": 23
+    },
+    {
+        "name": "minutes",
+        "range": 59
+    },
+]
 
 BOT_DEVS = [165023948638126080, 141288766760288256, 249287049482338305]

--- a/bot/extensions/timestamp.py
+++ b/bot/extensions/timestamp.py
@@ -1,0 +1,202 @@
+from discord import Embed
+from discord.colour import Colour
+from discord.ext.commands import Cog
+from discord_slash import cog_ext
+from discord_slash.context import SlashContext
+from discord_slash.utils.manage_commands import create_option, create_choice
+
+from bot import DiscordModeratorWumpus
+from bot.utils import timestamp_validity
+
+from datetime import datetime, timedelta
+import dateutil.tz
+from calendar import month_name
+
+
+class Timestamp(Cog):
+    """Commands for creating timestamps"""
+
+    def __init__(self, bot: DiscordModeratorWumpus) -> None:
+        self.bot = bot
+
+    @cog_ext.cog_subcommand(
+        base="timestamp",
+        name="make",
+        description="Returns embeddable timestamp",
+        options=[
+            create_option(
+                name="year",
+                description="Year of date",
+                option_type=4,
+                required=True,
+            ),
+            create_option(
+                name="month",
+                description="Month of date",
+                option_type=4,
+                required=True,
+                choices=[
+                    create_choice(1, "January"),
+                    create_choice(2, "February"),
+                    create_choice(3, "March"),
+                    create_choice(4, "April"),
+                    create_choice(5, "May"),
+                    create_choice(6, "June"),
+                    create_choice(7, "July"),
+                    create_choice(8, "August"),
+                    create_choice(9, "September"),
+                    create_choice(10, "October"),
+                    create_choice(11, "November"),
+                    create_choice(12, "December"),
+                ]
+            ),
+            create_option(
+                name="day",
+                description="Day of date",
+                option_type=4,
+                required=True,
+            ),
+            create_option(
+                name="hour",
+                description="Hour of time in 24 hour format",
+                option_type=4,
+                required=True,
+            ),
+            create_option(
+                name="minute",
+                description="Minute of time",
+                option_type=4,
+                required=True,
+            ),
+            create_option(
+                name="utc",
+                description="UTC offset, defaults to 0, range -12 -> 14",
+                option_type=4,
+                required=False,
+            ),
+            create_option(
+                name="tag",
+                description="Tag for format, defaults to short date/time",
+                option_type=3,
+                required=False,
+                choices=[
+                    create_choice("t", "Short Time"),
+                    create_choice("T", "Long Time"),
+                    create_choice("d", "Short Date"),
+                    create_choice("D", "Long Time"),
+                    create_choice("f", "Short Date/Time"),
+                    create_choice("F", "Long Date/Time"),
+                    create_choice("R", "Relative Time"),
+
+                ]
+            )
+        ],
+    )
+    async def _timestamp_make(self, ctx: SlashContext, year: int, month: int, day: int, hour: int, minute: int, utc: int = 0, tag: str = "f"):
+        validity_check = timestamp_validity.make_data_validity(year, month, day, hour, minute, utc)
+
+        if len(validity_check) == 0:
+            dt = datetime(year, month, day, hour, minute, 0, 0, tzinfo=dateutil.tz.tzoffset(None, 3600 * utc))
+            ts = int(dt.timestamp())
+            embed = Embed(title="Timestamp Created", color=Colour.blurple())
+            embed.add_field(name="Output", value=f"<t:{ts}:{tag}>")
+            embed.add_field(name="Copyable", value=f"\<t:{ts}:{tag}\>")
+            await ctx.send(embed=embed, hidden=True)
+
+        else:
+            embed = Embed(colour=Colour.blurple(), title="Timestamp Error")
+            for error in validity_check:
+                extra = ""
+
+                if error["name"] == "day":
+                    extra = f" for {month_name[month]}"
+                    if month == 2:
+                        extra += f" {year}"
+
+                embed.add_field(
+                    name="Field Error",
+                    value=f'You inputted {error["input"]} for field `{error["name"]}`. Field must be between '
+                          f'{error["min"]} and {error["max"]} inclusively{extra}.',
+                    inline=False,
+                )
+            await ctx.send(embed=embed, hidden=True)
+
+    @cog_ext.cog_subcommand(
+        base="timestamp",
+        name="now",
+        description="Returns the current date and time in UTC and your timezone",
+    )
+    async def _timestamp_now(self, ctx: SlashContext):
+        time = datetime.utcnow()
+        embed = Embed(title="Current Time", color=Colour.blurple())
+        embed.add_field(name="UTC Time", value=time.strftime("%A, %B %d, %Y %-I:%M %p"), inline=False)
+        embed.add_field(name="Local Time", value=f"<t:{int(time.timestamp())}:F>", inline=False)
+        await ctx.send(embed=embed, hidden=True)
+
+    @cog_ext.cog_subcommand(
+        base="timestamp",
+        name="relative",
+        description="Returns a timestamp relative to current time",
+        options=[
+            create_option(
+                name="days",
+                description="Days relative to now, +- 730500 days inclusively",
+                option_type=4,
+                required=False,
+            ),
+            create_option(
+                name="hours",
+                description="Hours relative to now, += 23 hours inclusively",
+                option_type=4,
+                required=False,
+            ),
+            create_option(
+                name="minutes",
+                description="Minutes relative to now, +- 59 minutes inclusively",
+                option_type=4,
+                required=False,
+            ),
+            create_option(
+                name="tag",
+                description="Tag for format, defaults to short date/time",
+                option_type=3,
+                required=False,
+                choices=[
+                    create_choice("t", "Short Time"),
+                    create_choice("T", "Long Time"),
+                    create_choice("d", "Short Date"),
+                    create_choice("D", "Long Time"),
+                    create_choice("f", "Short Date/Time"),
+                    create_choice("F", "Long Date/Time"),
+                    create_choice("R", "Relative Time"),
+
+                ]
+            )
+        ]
+    )
+    async def _timestamp_relative(self, ctx: SlashContext, days: int = 0, hours: int = 0, minutes: int = 0, tag: str = "f"):
+        validity_check = timestamp_validity.relative_data_validity(days, hours, minutes)
+        if len(validity_check) == 0:
+            time = datetime.utcnow()
+            td = timedelta(days=days, hours=hours, minutes=minutes)
+            time = time + td
+            ts = int(time.timestamp())
+            embed = Embed(title="Relative Time", color=Colour.blurple(), description=f"Time shifted by {td}")
+            embed.add_field(name="Output", value=f"<t:{ts}:{tag}>", inline=False)
+            embed.add_field(name="Copyable", value=f"\<t:{ts}:{tag}\>", inline=False)
+            await ctx.send(embed=embed, hidden=True)
+
+        else:
+            embed = Embed(colour=Colour.blurple(), title="Timestamp Error")
+            for error in validity_check:
+                embed.add_field(
+                    name="Field Error",
+                    value=f'You inputted {error["input"]} for field `{error["name"]}`. Field must be within '
+                          f'the range +-{error["range"]}.',
+                    inline=False,
+                )
+            await ctx.send(embed=embed, hidden=True)
+
+
+def setup(bot: DiscordModeratorWumpus) -> None:
+    bot.add_cog(Timestamp(bot))

--- a/bot/extensions/timestamp.py
+++ b/bot/extensions/timestamp.py
@@ -48,7 +48,7 @@ class Timestamp(Cog):
                     create_choice(10, "October"),
                     create_choice(11, "November"),
                     create_choice(12, "December"),
-                ]
+                ],
             ),
             create_option(
                 name="day",
@@ -87,16 +87,27 @@ class Timestamp(Cog):
                     create_choice("f", "Short Date/Time"),
                     create_choice("F", "Long Date/Time"),
                     create_choice("R", "Relative Time"),
-
-                ]
-            )
+                ],
+            ),
         ],
     )
-    async def _timestamp_make(self, ctx: SlashContext, year: int, month: int, day: int, hour: int, minute: int, utc: int = 0, tag: str = "f"):
+    async def _timestamp_make(
+        self,
+        ctx: SlashContext,
+        year: int,
+        month: int,
+        day: int,
+        hour: int,
+        minute: int,
+        utc: int = 0,
+        tag: str = "f",
+    ):
         validity_check = timestamp_validity.make_data_validity(year, month, day, hour, minute, utc)
 
         if len(validity_check) == 0:
-            dt = datetime(year, month, day, hour, minute, 0, 0, tzinfo=dateutil.tz.tzoffset(None, 3600 * utc))
+            dt = datetime(
+                year, month, day, hour, minute, 0, 0, tzinfo=dateutil.tz.tzoffset(None, 3600 * utc)
+            )
             ts = int(dt.timestamp())
             embed = Embed(title="Timestamp Created", color=Colour.blurple())
             embed.add_field(name="Output", value=f"<t:{ts}:{tag}>")
@@ -116,7 +127,7 @@ class Timestamp(Cog):
                 embed.add_field(
                     name="Field Error",
                     value=f'You inputted {error["input"]} for field `{error["name"]}`. Field must be between '
-                          f'{error["min"]} and {error["max"]} inclusively{extra}.',
+                    f'{error["min"]} and {error["max"]} inclusively{extra}.',
                     inline=False,
                 )
             await ctx.send(embed=embed, hidden=True)
@@ -129,7 +140,9 @@ class Timestamp(Cog):
     async def _timestamp_now(self, ctx: SlashContext):
         time = datetime.utcnow()
         embed = Embed(title="Current Time", color=Colour.blurple())
-        embed.add_field(name="UTC Time", value=time.strftime("%A, %B %d, %Y %-I:%M %p"), inline=False)
+        embed.add_field(
+            name="UTC Time", value=time.strftime("%A, %B %d, %Y %-I:%M %p"), inline=False
+        )
         embed.add_field(name="Local Time", value=f"<t:{int(time.timestamp())}:F>", inline=False)
         await ctx.send(embed=embed, hidden=True)
 
@@ -169,19 +182,22 @@ class Timestamp(Cog):
                     create_choice("f", "Short Date/Time"),
                     create_choice("F", "Long Date/Time"),
                     create_choice("R", "Relative Time"),
-
-                ]
-            )
-        ]
+                ],
+            ),
+        ],
     )
-    async def _timestamp_relative(self, ctx: SlashContext, days: int = 0, hours: int = 0, minutes: int = 0, tag: str = "f"):
+    async def _timestamp_relative(
+        self, ctx: SlashContext, days: int = 0, hours: int = 0, minutes: int = 0, tag: str = "f"
+    ):
         validity_check = timestamp_validity.relative_data_validity(days, hours, minutes)
         if len(validity_check) == 0:
             time = datetime.utcnow()
             td = timedelta(days=days, hours=hours, minutes=minutes)
             time = time + td
             ts = int(time.timestamp())
-            embed = Embed(title="Relative Time", color=Colour.blurple(), description=f"Time shifted by {td}")
+            embed = Embed(
+                title="Relative Time", color=Colour.blurple(), description=f"Time shifted by {td}"
+            )
             embed.add_field(name="Output", value=f"<t:{ts}:{tag}>", inline=False)
             embed.add_field(name="Copyable", value=f"\<t:{ts}:{tag}\>", inline=False)
             await ctx.send(embed=embed, hidden=True)
@@ -192,7 +208,7 @@ class Timestamp(Cog):
                 embed.add_field(
                     name="Field Error",
                     value=f'You inputted {error["input"]} for field `{error["name"]}`. Field must be within '
-                          f'the range +-{error["range"]}.',
+                    f'the range +-{error["range"]}.',
                     inline=False,
                 )
             await ctx.send(embed=embed, hidden=True)

--- a/bot/extensions/timestamp.py
+++ b/bot/extensions/timestamp.py
@@ -102,7 +102,15 @@ class Timestamp(Cog):
         utc: int = 0,
         tag: str = "f",
     ):
-        validity_check = timestamp_validity.make_data_validity(year, month, day, hour, minute, utc)
+        input_data = {
+            "year": year,
+            "month": month,
+            "day": day,
+            "hour": hour,
+            "minute": minute,
+            "utc": utc,
+        }
+        validity_check = timestamp_validity.make_data_validity(input_data)
 
         if len(validity_check) == 0:
             dt = datetime(
@@ -189,7 +197,8 @@ class Timestamp(Cog):
     async def _timestamp_relative(
         self, ctx: SlashContext, days: int = 0, hours: int = 0, minutes: int = 0, tag: str = "f"
     ):
-        validity_check = timestamp_validity.relative_data_validity(days, hours, minutes)
+        input_data = {"days": days, "hours": hours, "minutes": minutes}
+        validity_check = timestamp_validity.relative_data_validity(input_data)
         if len(validity_check) == 0:
             time = datetime.utcnow()
             td = timedelta(days=days, hours=hours, minutes=minutes)

--- a/bot/utils/dma_api.py
+++ b/bot/utils/dma_api.py
@@ -54,7 +54,7 @@ async def get_search_api(query_string: str = None, series_number: int = None):
         url_params["query"] = f"{{{query_string}}}"
 
     if series_number:
-        url_params["section"] = series_number
+        url_params["section"] = DMA_SERIES_IDS[series_number]
 
     request_url = f'{DMA_API_SEARCH_URL}?{parse.urlencode(url_params)}'
     

--- a/bot/utils/timestamp_validity.py
+++ b/bot/utils/timestamp_validity.py
@@ -1,0 +1,29 @@
+from bot.constants import TIMESTAMP_MAKE_BOUNDARIES, TIMESTAMP_RELATIVE_BOUNDARIES
+from copy import deepcopy
+
+
+def make_data_validity(year: int, month: int, day: int, hour: int, minute: int, utc: int):
+    invalid_fields = []
+    boundaries = deepcopy(TIMESTAMP_MAKE_BOUNDARIES)
+    for item in boundaries:
+        input_value = locals()[item["name"]]
+        if item["min"] > input_value:
+            item["input"] = input_value
+            invalid_fields.append(item)
+        if item["name"] == "day":
+            item["max"] = item["max"](year, month)
+        if item["max"] < input_value:
+            item["input"] = input_value
+            invalid_fields.append(item)
+    return invalid_fields
+
+
+def relative_data_validity(days: int, hours: int, minutes: int):
+    invalid_fields = []
+    boundaries = deepcopy(TIMESTAMP_RELATIVE_BOUNDARIES)
+    for item in boundaries:
+        input_value = locals()[item["name"]]
+        if item["range"] < input_value:
+            item["input"] = input_value
+            invalid_fields.append(item)
+    return invalid_fields

--- a/bot/utils/timestamp_validity.py
+++ b/bot/utils/timestamp_validity.py
@@ -2,27 +2,27 @@ from bot.constants import TIMESTAMP_MAKE_BOUNDARIES, TIMESTAMP_RELATIVE_BOUNDARI
 from copy import deepcopy
 
 
-def make_data_validity(year: int, month: int, day: int, hour: int, minute: int, utc: int):
+def make_data_validity(input_data: dict):
     invalid_fields = []
     boundaries = deepcopy(TIMESTAMP_MAKE_BOUNDARIES)
     for item in boundaries:
-        input_value = locals()[item["name"]]
+        input_value = input_data[item["name"]]
         if item["min"] > input_value:
             item["input"] = input_value
             invalid_fields.append(item)
         if item["name"] == "day":
-            item["max"] = item["max"](year, month)
+            item["max"] = item["max"](input_data["year"], input_data["month"])
         if item["max"] < input_value:
             item["input"] = input_value
             invalid_fields.append(item)
     return invalid_fields
 
 
-def relative_data_validity(days: int, hours: int, minutes: int):
+def relative_data_validity(input_data: dict):
     invalid_fields = []
     boundaries = deepcopy(TIMESTAMP_RELATIVE_BOUNDARIES)
     for item in boundaries:
-        input_value = locals()[item["name"]]
+        input_value = input_data[item["name"]]
         if item["range"] < input_value:
             item["input"] = input_value
             invalid_fields.append(item)


### PR DESCRIPTION
This PR implements the approved suggestion for a timestamp feature [here](https://discord.com/channels/844686108125429801/846942055728808006/858808439068819467). This comes in the form of three subcommands.

/timestamp make - Creates a timestamp based on fields provided. Supports tags for which format to display.

/timestamp now - returns the current date and time in UTC and a timestamp in the Long Date/Time format. This is to allow people to easily see their UTC offset, as it's currently impossible to get timezone implicitly.

/timestamp relative - returns a timestamp offset from the current time by the amount of days, hours, and minutes provided. Supports tags for which format to display.